### PR TITLE
Allow commands in arena.yml to contain colons

### DIFF
--- a/src/main/java/tk/shanebee/hg/game/GameCommandData.java
+++ b/src/main/java/tk/shanebee/hg/game/GameCommandData.java
@@ -53,7 +53,7 @@ public class GameCommandData extends Data {
             String type = command.split(":")[0];
             if (!type.equals(commandType.getType())) continue;
             if (command.equalsIgnoreCase("none")) continue;
-            command = command.split(":")[1]
+            command = command.split(":", 2)[1]
                     .replace("<world>", game.gameArenaData.bound.getWorld().getName())
                     .replace("<arena>", game.gameArenaData.getName());
             if (player != null) {


### PR DESCRIPTION
Update `GameCommandData#runCommands` to grab the command as everything after the first colon in the input string. (for example, the string in arena.yml under the commands section might be `start:give <player> minecraft:stone 32` and the command would be grabbed properly as `give <player> minecraft:stone 32` instead of `give <player> minecraft`).