### PR TITLE
Update HG.java with initilization for NBTApi object

### DIFF
--- a/src/main/java/tk/shanebee/hg/HG.java
+++ b/src/main/java/tk/shanebee/hg/HG.java
@@ -105,7 +105,9 @@ public class HG extends JavaPlugin {
 			Bukkit.getLogger().info("Your Java Version is " + System.getProperty("java.version") + " This plugin is compatible with your version");
 		}
 		PaperLib.suggestPaper(this);
-
+	    
+	    	// NBT Api init
+		nbtApi = new NBTApi();
 
 		//MythicMob check
 		if (Bukkit.getPluginManager().isPluginEnabled("MythicMobs")) {


### PR DESCRIPTION
A very quick fix to get the NBTApi to function properly.

I am unsure whether this is a change with the NBT API or spigot 1.19.3, but the API is not initialized properly when the plugin tries to load the NBT string for custom items in ItemStackManager class.

Initializing it on plugin enable ensures the NBTApi object is not null and won't cause a crash or prevent nbt tagged items from loading.

There might be something deeper here, but this is what I was able to get the plugin functional again.