### PR TITLE
Add randomness to whether a chest is bonus or not.

### DIFF
--- a/src/main/java/tk/shanebee/hg/data/Config.java
+++ b/src/main/java/tk/shanebee/hg/data/Config.java
@@ -42,6 +42,8 @@ public class Config {
     public static boolean enableforcestartitem;
     public static String leaveitemtype;
     public static String forcestartitem;
+    public static boolean bonusRandom;
+    public static double bonusChance;
 
     //Team info
     public static boolean team_showTeamNames;
@@ -135,6 +137,8 @@ public class Config {
         enableforcestartitem = config.getBoolean("settings.enable-force-start-item");
         leaveitemtype = config.getString("settings.leave-item-type");
         forcestartitem = config.getString("settings.force-start-item-type");
+        bonusRandom = config.getBoolean("settings.bonus-random");
+        bonusChance = config.getDouble("settings.bonus-chance");
 
         // Team
         team_maxTeamSize = config.getInt("team.max-team-size");

--- a/src/main/java/tk/shanebee/hg/listeners/GameListener.java
+++ b/src/main/java/tk/shanebee/hg/listeners/GameListener.java
@@ -41,6 +41,7 @@ import tk.shanebee.hg.util.Util;
 
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Random;
 import java.util.UUID;
 
 /**
@@ -364,7 +365,20 @@ public class GameListener implements Listener {
 			PlayerData pd = playerManager.getPlayerData(player);
 			if (gameManager.getGame(player.getLocation()) == null) return;
 			if (gameManager.getGame(player.getLocation()).getGameArenaData().getStatus()  == Status.COUNTDOWN  || gameManager.getGame(player.getLocation()).getGameArenaData().getStatus()  == Status.WAITING) event.setCancelled(true);
-			if (block.getType() == Material.CHEST) {
+
+			if(Config.bonusRandom){
+				int random = Math.toIntExact((long) (Config.bonusChance*10));
+				Random ran = new Random();
+				int chance = ran.nextInt(10);
+				if(chance<=random){
+                    assert pd != null;
+                    Bukkit.getServer().getPluginManager().callEvent(new ChestOpenEvent(pd.getGame(), block, true));
+				} else{
+                    assert pd != null;
+                    Bukkit.getServer().getPluginManager().callEvent(new ChestOpenEvent(pd.getGame(), block, false));
+				}
+			}
+			else if (block.getType() == Material.CHEST) {
 				assert pd != null;
 				Bukkit.getServer().getPluginManager().callEvent(new ChestOpenEvent(pd.getGame(), block, false));
 			} else if (BlockUtils.isBonusBlock(block)) {
@@ -383,7 +397,6 @@ public class GameListener implements Listener {
         ItemStack item = event.getItem();
         if (item == null || item.getType() != Material.COMPASS) return false;
         return item.getItemMeta() != null && item.getItemMeta().getDisplayName().equalsIgnoreCase(Util.getColString(lang.spectator_compass));
-
     }
 
     private void handleSpectatorCompass(Player player) {

--- a/src/main/java/tk/shanebee/hg/managers/Manager.java
+++ b/src/main/java/tk/shanebee/hg/managers/Manager.java
@@ -159,7 +159,7 @@ public class Manager {
     /** Fill chests in a game
      * @param inv Inventory to fill
      * @param game Game this chest is in
-     * @param bonus Whether or not this is a bonus chest
+     * @param bonus Whether this is a bonus chest
      */
 	public void fillChest(Inventory inv, Game game, boolean bonus) {
 		GameItemData gameItemData = game.getGameItemData();
@@ -179,6 +179,7 @@ public class Manager {
 		Collections.shuffle(itemList);
 
 		int costGoal = rg.nextInt(minCost, maxCost + 1);
+
 		int chestCost = 0;
 		ArrayList<ItemStack> chestContents = new ArrayList<>();
 		int numTries = 0;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -53,6 +53,10 @@ settings:
         - TRAPPED_CHEST
         - BARREL
         - tag:shulker_boxes
+    # When enabled, bonus chests are randomly chosen.
+    bonus-random: false
+    # Chance for a chest to be bonus (between 0 and 1) (only works if bonus-random is enabled)
+    bonus-chance: 0.1
     # When enabled, name tags will be hidden from all players in the game
     hide-nametags: true
     # Enables an item to click to leave game while waiting


### PR DESCRIPTION
Setting **bonus-random** to true will make all chests in any arena have its loot-table randomly chosen. 

**bonus-chance** is a normalized double which you can set between 0.1 and 1 to set the chances of a chest being bonus. **bonus-chance** will be converted to its closest integer during runtime.