### PR TITLE
Make lobby signs optional

### DIFF
--- a/src/main/java/tk/shanebee/hg/data/ArenaConfig.java
+++ b/src/main/java/tk/shanebee/hg/data/ArenaConfig.java
@@ -114,6 +114,7 @@ public class ArenaConfig {
 					int maxplayers = 0;
 					Bound bound = null;
 					List<String> commands;
+					World world = null;
 
 					String path = "arenas." + arenaName;
 					try {
@@ -131,10 +132,8 @@ public class ArenaConfig {
 
 					try {
 						lobbysign = (Sign) getSLoc(arenadat.getString(path + ".lobbysign")).getBlock().getState();
-					} catch (Exception e) { 
-						Util.warning("Unable to load lobby sign for arena '" + arenaName + "'!");
-						Util.debug(e);
-						isReady = false;
+					} catch (Exception e) {
+						// lobby sign not required
 					}
 
 					try {
@@ -148,17 +147,21 @@ public class ArenaConfig {
 
 					try {
 						bound = new Bound(arenadat.getString(path + ".bound.world"), BC(arenaName, "x"), BC(arenaName, "y"), BC(arenaName, "z"), BC(arenaName, "x2"), BC(arenaName, "y2"), BC(arenaName, "z2"));
+						world = bound.getWorld();
 					} catch (Exception e) { 
 						Util.warning("Unable to load region bounds for arena " + arenaName + "!");
+						isReady = false;
+					}
+
+					if (world == null) {
+						Util.warning("The world for arena '%s' does not exist!", arenaName);
 						isReady = false;
 					}
 
 					Game game = new Game(arenaName, bound, spawns, lobbysign, timer, minplayers, maxplayers, freeroam, isReady, cost);
 					plugin.getGames().add(game);
 
-					World world = bound.getWorld();
 					if (world == null) {
-						Util.warning("World '%s' for arena '%s' does not exist!", arenaName, arenaName);
 						continue;
 					}
 

--- a/src/main/java/tk/shanebee/hg/game/Game.java
+++ b/src/main/java/tk/shanebee/hg/game/Game.java
@@ -74,9 +74,8 @@ public class Game {
         gameArenaData.spawns.addAll(spawns);
         this.gameBlockData.sign1 = lobbySign;
 
-        // If lobby signs are not properly setup, game is not ready
-        if (!this.gameBlockData.setLobbyBlock(lobbySign)) {
-            isReady = false;
+        if (lobbySign != null) {
+            this.gameBlockData.setLobbyBlock(lobbySign);
         }
         gameArenaData.setStatus(isReady ? Status.READY : Status.BROKEN);
 

--- a/src/main/java/tk/shanebee/hg/game/GamePlayerData.java
+++ b/src/main/java/tk/shanebee/hg/game/GamePlayerData.java
@@ -331,7 +331,9 @@ public class GamePlayerData extends Data {
                         msgAll(broadcast);
                     }
                 }
-                kitHelp(player);
+                if (game.kitManager.hasKits()) {
+                    kitHelp(player);
+                }
 
                 game.gameBlockData.updateLobbyBlock();
                 game.gameArenaData.updateBoards();

--- a/src/main/java/tk/shanebee/hg/managers/Manager.java
+++ b/src/main/java/tk/shanebee/hg/managers/Manager.java
@@ -1,6 +1,7 @@
 package tk.shanebee.hg.managers;
 
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.block.Sign;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.Configuration;
@@ -52,6 +53,7 @@ public class Manager {
 		int borderCountdownStart = 0;
 		int borderCountdownEnd = 0;
 		int chestRefill = 0;
+		World world = null;
 
 		try {
 			timer = arenadat.getInt("arenas." + gameName + ".info." + "timer");
@@ -106,10 +108,17 @@ public class Manager {
 		try {
 			@SuppressWarnings("unused")
             Bound b = new Bound(arenadat.getString("arenas." + gameName + ".bound." + "world"), HG.getPlugin().getArenaConfig().BC(gameName, "x"), HG.getPlugin().getArenaConfig().BC(gameName, "y"), HG.getPlugin().getArenaConfig().BC(gameName, "z"), HG.getPlugin().getArenaConfig().BC(gameName, "x2"), HG.getPlugin().getArenaConfig().BC(gameName, "y2"), HG.getPlugin().getArenaConfig().BC(gameName, "z2"));
+			world = b.getWorld();
 		} catch (Exception e) {
 			Util.scm(sender, "&cUnable to load region bounds for arena " + gameName + "!");
 			isReady = false;
 		}
+
+		if (world == null) {
+			Util.scm(sender, "&cThe world for this arena does not exist!");
+			isReady = false;
+		}
+
 		if (isReady) {
 			Util.scm(sender,"&7&l---= &3&lYour HungerGames arena is ready to run! &7&l=---");
 			Util.scm(sender, "&7Spawns:&b " + spawns.size());

--- a/src/main/java/tk/shanebee/hg/managers/Manager.java
+++ b/src/main/java/tk/shanebee/hg/managers/Manager.java
@@ -18,6 +18,7 @@ import tk.shanebee.hg.game.GameItemData;
 import tk.shanebee.hg.util.Util;
 
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * General manager for games
@@ -26,7 +27,7 @@ public class Manager {
 
 	private final HG plugin;
 	private final Language lang;
-	private final Random rg = new Random();
+	private final ThreadLocalRandom rg = ThreadLocalRandom.current();
 
 	public Manager(HG plugin) {
 		this.plugin = plugin;


### PR DESCRIPTION
I do not use the lobby signs feature, and keeping track of them is annoying when I switch out my lobby world. This pull request makes them optional, and tweaks the arena validation system accordingly. 

While I was at it I made a few other small fixes:
- The kit help message will no longer show up if there are no kits.
- Changed Random to ThreadLocalRandom for compatibility with Java 16.